### PR TITLE
feat(player): expose current track via CurrentTrack() accessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Build directories
+build/
+build*/
+out/
+cmake-build-*/
+
+# CMake
+CMakeCache.txt
+CMakeFiles/
+CMakeScripts/
+Testing/
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps/
+
+# Compiled object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled headers
+*.gch
+*.pch
+
+# Compiled dynamic/static libraries
+*.so
+*.so.*
+*.dylib
+*.dll
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*~
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,10 @@
+option(CXXMIDI_BUILD_QT_EXAMPLES "Build Qt-based examples" OFF)
+
 add_subdirectory(callbacks)
-add_subdirectory(qtmidieditor)
-add_subdirectory(qtmidiplayer)
+if(CXXMIDI_BUILD_QT_EXAMPLES)
+  add_subdirectory(qtmidieditor)
+  add_subdirectory(qtmidiplayer)
+endif()
 add_subdirectory(player_async)
 add_subdirectory(player_sync)
 add_subdirectory(sequencing)

--- a/include/cxxmidi/guts/player_base.hpp
+++ b/include/cxxmidi/guts/player_base.hpp
@@ -76,6 +76,8 @@ class PlayerBase {
   inline void SetCallbackFinished(const std::function<void()>& callback);
   inline void SetCallbackEvent(const std::function<bool(Event& event)>& callback);
 
+  inline size_t CurrentTrack() const { return current_track_; }
+
  protected:
   inline bool TrackFinished(size_t track_num) const;
   inline unsigned int TrackPending() const;
@@ -86,8 +88,9 @@ class PlayerBase {
   float speed_;
   const File* file_;
   std::chrono::microseconds played_us_;
+  size_t current_track_;
 
-  inline void ExecEvent(const Event& event);
+  inline void ExecEvent(const Event& event, size_t track_num);
 
   class PlayerStateElem {
    public:
@@ -130,6 +133,7 @@ PlayerBase::PlayerBase()
       speed_(1.),
       file_(nullptr),
       played_us_(std::chrono::microseconds(0)),
+      current_track_(0),
       output_(0),
       heartbeat_helper_(0) {
   PlayerBase::SetupWindowsTimers();
@@ -141,6 +145,7 @@ PlayerBase::PlayerBase(output::Abstract* output)
       speed_(1.),
       file_(nullptr),
       played_us_(std::chrono::microseconds(0)),
+      current_track_(0),
       output_(output),
       heartbeat_helper_(0) {
   PlayerBase::SetupWindowsTimers();
@@ -191,7 +196,7 @@ void PlayerBase::GoTo(const std::chrono::microseconds& pos) {
     Event event = (*file_)[track_mum][event_num];
     if (!event.IsVoiceCategory(Message::kNoteOn) &&
         !event.IsVoiceCategory(Message::kNoteOff))
-      ExecEvent(event);
+      ExecEvent(event, track_mum);
 
     UpdatePlayerState(track_mum, dt);
 
@@ -216,7 +221,7 @@ void PlayerBase::GoToTick(uint32_t tick)
     if ((message[0] == Message::kMeta && message[1] == Message::kTempo) ||
         (message[0] == Message::kMeta && message[1] == Message::kKeySignature))
         {
-            ExecEvent(event);
+            ExecEvent(event, track_num);
         }
 
     UpdatePlayerState(track_num, dt);
@@ -357,8 +362,10 @@ void PlayerBase::UpdatePlayerState(unsigned int track_num, unsigned int dt) {
     }
 }
 
-void PlayerBase::ExecEvent(const Event& event) {
+void PlayerBase::ExecEvent(const Event& event, size_t track_num) {
   Event ev(event);
+
+  current_track_ = track_num;
 
   bool send = true;   // Send events to output by default
 

--- a/include/cxxmidi/guts/simulator.hpp
+++ b/include/cxxmidi/guts/simulator.hpp
@@ -53,7 +53,7 @@ std::chrono::microseconds Simulator::Duration(const File &file) {
     unsigned int eventNum = player_state_[trackNum].track_pointer_;
     uint32_t dt = player_state_[trackNum].track_dt_;
     r += converters::Dt2us(dt, tempo_, file_->TimeDivision());
-    ExecEvent((*file_)[trackNum][eventNum]);
+    ExecEvent((*file_)[trackNum][eventNum], trackNum);
     UpdatePlayerState(trackNum, dt);
   }
 

--- a/include/cxxmidi/player/player_async.hpp
+++ b/include/cxxmidi/player/player_async.hpp
@@ -222,7 +222,7 @@ void* PlayerAsync::PlayerLoop(void* caller) {
       // cppcheck-suppress unreadVariable RAII
       std::scoped_lock lock(that->mutex_);
       that->played_us_ += std::chrono::microseconds(us);
-      that->ExecEvent((*that->file_)[track_num][event_num]);
+      that->ExecEvent((*that->file_)[track_num][event_num], track_num);
       that->UpdatePlayerState(track_num, dt);
     }
   }

--- a/include/cxxmidi/player/player_sync.hpp
+++ b/include/cxxmidi/player/player_sync.hpp
@@ -90,7 +90,7 @@ void PlayerSync::PlayerLoop() {
     std::this_thread::sleep_for(std::chrono::microseconds(wait));
     heartbeat_helper_ += us.count();
     played_us_ += std::chrono::microseconds(us);
-    ExecEvent((*file_)[track_num][event_num]);
+    ExecEvent((*file_)[track_num][event_num], track_num);
     UpdatePlayerState(track_num, dt);
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(tests
   message.cpp
   note.cpp
   other.cpp
-  player_base.cpp)
+  player_base.cpp
+  player_sync.cpp)
 
 target_compile_options(tests PRIVATE -Wall -pedantic -Wextra)
 target_compile_features(tests PRIVATE cxx_std_17)

--- a/tests/player_sync.cpp
+++ b/tests/player_sync.cpp
@@ -1,0 +1,68 @@
+/* *****************************************************************************
+Copyright (c) 2018 Stan Chlebicki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***************************************************************************** */
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <cxxmidi/file.hpp>
+#include <cxxmidi/note.hpp>
+#include <cxxmidi/output/null.hpp>
+#include <cxxmidi/player/player_sync.hpp>
+
+TEST(PlayerSync, CurrentTrackDuringCallback) {
+  cxxmidi::File file;
+
+  // All deltatimes are 0, so PlayerSync drains track 0 completely before
+  // moving on to track 1 (TrackPending() breaks ties toward the lower
+  // index), giving a fully deterministic event order to assert on.
+  cxxmidi::Track &track0 = file.AddTrack();
+  track0.push_back(cxxmidi::Event(0, cxxmidi::Message::kNoteOn,
+                                  cxxmidi::Note::MiddleC(), 100));
+  track0.push_back(cxxmidi::Event(0, cxxmidi::Message::kNoteOn,
+                                  cxxmidi::Note::MiddleC(), 0));
+  track0.push_back(
+      cxxmidi::Event(0, cxxmidi::Message::kMeta, cxxmidi::Message::kEndOfTrack));
+
+  cxxmidi::Track &track1 = file.AddTrack();
+  track1.push_back(cxxmidi::Event(0, cxxmidi::Message::kNoteOn,
+                                  cxxmidi::Note::MiddleC() + 2, 100));
+  track1.push_back(cxxmidi::Event(0, cxxmidi::Message::kNoteOn,
+                                  cxxmidi::Note::MiddleC() + 2, 0));
+  track1.push_back(
+      cxxmidi::Event(0, cxxmidi::Message::kMeta, cxxmidi::Message::kEndOfTrack));
+
+  cxxmidi::output::Null output;
+  cxxmidi::player::PlayerSync player(&output);
+  player.SetFile(&file);
+
+  std::vector<size_t> observed_tracks;
+  player.SetCallbackEvent([&](cxxmidi::Event & /*event*/) {
+    observed_tracks.push_back(player.CurrentTrack());
+    return true;
+  });
+
+  player.Play();
+
+  const std::vector<size_t> expected = {0, 0, 0, 1, 1, 1};
+  EXPECT_EQ(observed_tracks, expected);
+}


### PR DESCRIPTION
## Summary
- Add `PlayerBase::CurrentTrack()` so an event callback can find out which track an event came from, without changing `SetCallbackEvent`'s existing `std::function<bool(Event&)>` signature (fully backward compatible for existing callers).
- `ExecEvent()` now takes an explicit `track_num` and records it in a new `current_track_` member before invoking the callback. Updated all 5 call sites (`PlayerBase::GoTo`/`GoToTick`, `PlayerSync::PlayerLoop`, `PlayerAsync::PlayerLoop`, `Simulator::Duration`) — all of them needed the update for the header-only library to keep compiling, not just `PlayerSync`.
- Gate the Qt-based examples (`qtmidieditor`, `qtmidiplayer`) behind a new `CXXMIDI_BUILD_QT_EXAMPLES` option (default `OFF`), so a plain `cmake ..` configures cleanly on machines without Qt6 (e.g. a lean Raspberry Pi daemon appliance). `tests/` (GTest + ALSA) is unaffected and still builds/runs by default.

## Test plan
- [x] `cmake ..` configures cleanly with no Qt6 error
- [x] `cmake --build .` succeeds (library, all non-Qt examples, and tests all compile)
- [x] `ctest` — all 17 existing tests pass
- [x] Confirmed `examples/player_async` actually instantiates `PlayerAsync`, verifying the `player_async.hpp` call-site fix was load-bearing, not just for parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)