### PR TITLE
fix(player): make PlayerBase::_stopped atomic

### DIFF
--- a/include/cxxmidi/guts/player_base.hpp
+++ b/include/cxxmidi/guts/player_base.hpp
@@ -29,6 +29,7 @@ SOFTWARE.
 #include <assert.h>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>  // NOLINT() CPP11_INCLUDES
 #include <cstdint>
 #include <functional>
@@ -84,7 +85,7 @@ class PlayerBase {
 
   uint32_t tempo_;  // [us per quarternote]
   bool is_playing_;
-  bool _stopped;
+  std::atomic<bool> _stopped;
   float speed_;
   const File* file_;
   std::chrono::microseconds played_us_;


### PR DESCRIPTION
## Summary
- `PlayerBase::Stop()` writes `_stopped` from the caller's thread (e.g. a daemon's main poll thread) while `PlayerLoop()` reads it in its `while` condition on the playback thread — an unsynchronized cross-thread read/write, i.e. a data race.
- Changes `_stopped` from `bool` to `std::atomic<bool>` to fix the race. Pure type change: assignment and boolean reads work unchanged.

## Test plan
- [x] `cmake --build .` — builds cleanly (only a pre-existing unrelated warning)
- [x] `ctest` — 17/17 tests pass