### PR TITLE
fix(player_sync): check _stopped inside heartbeat chunk loop

### DIFF
--- a/include/cxxmidi/player/player_sync.hpp
+++ b/include/cxxmidi/player/player_sync.hpp
@@ -74,7 +74,7 @@ void PlayerSync::PlayerLoop() {
     uint32_t dt = player_state_[track_num].track_dt_;
     auto us = converters::Dt2us(dt, tempo_, file_->TimeDivision());
 
-    while ((heartbeat_helper_ + us.count()) >= 10000) {
+    while (!_stopped && (heartbeat_helper_ + us.count()) >= 10000) {
       unsigned int partial = 10000 - heartbeat_helper_;
       heartbeat_helper_ = 0;
       us -= std::chrono::microseconds(partial);
@@ -85,6 +85,8 @@ void PlayerSync::PlayerLoop() {
 
       if (clbk_fun_heartbeat_) clbk_fun_heartbeat_();
     }
+
+    if (_stopped) break;
 
     unsigned int wait = us.count() / speed_;
     std::this_thread::sleep_for(std::chrono::microseconds(wait));

--- a/tests/player_sync.cpp
+++ b/tests/player_sync.cpp
@@ -22,6 +22,7 @@ SOFTWARE.
 
 #include <gtest/gtest.h>
 
+#include <chrono>  // NOLINT() CPP11_INCLUDES
 #include <vector>
 
 #include <cxxmidi/file.hpp>
@@ -65,4 +66,42 @@ TEST(PlayerSync, CurrentTrackDuringCallback) {
 
   const std::vector<size_t> expected = {0, 0, 0, 1, 1, 1};
   EXPECT_EQ(observed_tracks, expected);
+}
+
+TEST(PlayerSync, StopDuringLongGapReturnsPromptly) {
+  cxxmidi::File file;
+
+  // Default tempo (500000 us/quarternote) and time division (500
+  // ticks/quarternote) give 1000us/tick, so dt=150 is a 150ms gap before
+  // the first event fires -- 15 chunks of PlayerLoop()'s ~10ms heartbeat.
+  cxxmidi::Track &track0 = file.AddTrack();
+  track0.push_back(cxxmidi::Event(150, cxxmidi::Message::kNoteOn,
+                                  cxxmidi::Note::MiddleC(), 100));
+  track0.push_back(
+      cxxmidi::Event(0, cxxmidi::Message::kMeta, cxxmidi::Message::kEndOfTrack));
+
+  cxxmidi::output::Null output;
+  cxxmidi::player::PlayerSync player(&output);
+  player.SetFile(&file);
+
+  int heartbeats = 0;
+  std::vector<int> observed_events;
+  player.SetCallbackHeartbeat([&]() {
+    heartbeats++;
+    if (heartbeats == 2) player.Stop();
+  });
+  player.SetCallbackEvent([&](cxxmidi::Event & /*event*/) {
+    observed_events.push_back(1);
+    return true;
+  });
+
+  const auto start = std::chrono::steady_clock::now();
+  player.Play();
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  // Stop() lands during the 3rd ~10ms chunk of the 150ms gap. Without the
+  // fix, PlayerLoop() sleeps out the rest of the gap regardless (~150ms);
+  // with the fix it unwinds within about one more chunk.
+  EXPECT_LT(elapsed, std::chrono::milliseconds(75));
+  EXPECT_TRUE(observed_events.empty());
 }


### PR DESCRIPTION
## Summary
- `PlayerSync::PlayerLoop()` breaks long inter-event gaps into ~10ms heartbeat chunks (for `RitardandoEffector` ticks), but only checked `_stopped` in the *outer* loop condition, not inside the inner chunked-sleep loop.
- Result: calling `Stop()` during a long gap (e.g. a multi-second fermata/rest — normal in hymn playback) had no effect until the entire gap finished sleeping through all its chunks. `Player::stop()`/`NotesOff()` already ran immediately; the delay was purely in `PlayerLoop()`'s sleep granularity.
- Fix: check `!_stopped` in the inner loop's condition, and `break` out of the outer loop right after if a stop was observed, skipping the trailing per-event sleep/`ExecEvent`/`UpdatePlayerState`. Bounds stop latency to ~one 10ms chunk instead of the full remaining gap.
- `PlayerAsync::PlayerLoop()` is unaffected — it uses its own mutex-protected `pause_request_`, already checked inside its inner loop.

## Test plan
- [x] Added `PlayerSync.StopDuringLongGapReturnsPromptly` — stops mid-gap, asserts `PlayerLoop()` returns well under the full 150ms gap and the pending event never fires.
- [x] Confirmed the new test fails against the pre-fix code (~153ms elapsed, event fired) and passes with the fix.
- [x] `cmake --build .` — builds cleanly
- [x] `ctest` — 18/18 tests pass